### PR TITLE
Slim::EmbeddedEngine is deprecated, it is called Slim::Embedded in Slim 2.0

### DIFF
--- a/lib/coffee_views/slim.rb
+++ b/lib/coffee_views/slim.rb
@@ -3,7 +3,7 @@ ActiveSupport.on_load(:action_view) do
   if Object.const_defined?(:Slim)
 
     module CoffeeViews
-      class CoffeeViewEngine < Slim::EmbeddedEngine::ERBEngine
+      class CoffeeViewEngine < Slim::Embedded::ERBEngine
         def on_slim_embedded(engine, body)
           erb = collect_text(body)
           source = CoffeeViews::Rails::TemplateHandler.compile_coffee(erb)
@@ -22,9 +22,9 @@ ActiveSupport.on_load(:action_view) do
           end
         end
       end
-      
-      Slim::EmbeddedEngine.register :coffeeview,
-                                    ::Slim::EmbeddedEngine::TagEngine,
+
+      Slim::Embedded.register :coffeeview,
+                                    ::Slim::Embedded::TagEngine,
                                     :tag => :script,
                                     :attributes => { :type => 'text/javascript' },
                                     :engine => CoffeeViewEngine


### PR DESCRIPTION
We need more works to support an older version of slim. But if new release depends on latest slim it'll be ok. I keep the gemspec file untouched because I don't know the policy.
